### PR TITLE
Removing unused event

### DIFF
--- a/src/aura/autocompleteEvent/autocompleteEvent.evt
+++ b/src/aura/autocompleteEvent/autocompleteEvent.evt
@@ -1,3 +1,0 @@
-<aura:event type="COMPONENT">
-    <aura:attribute name="selectedOption" type="Object"/>
-</aura:event>

--- a/src/aura/autocompleteEvent/autocompleteEvent.evt-meta.xml
+++ b/src/aura/autocompleteEvent/autocompleteEvent.evt-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>33.0</apiVersion>
-    <description>DESCRIPTION</description>
-</AuraDefinitionBundle>


### PR DESCRIPTION
This event is no longer used by autocomplete but was not deletable because it was already added to the CampTools package. Removing from shared component and will add back directly to CampTools.